### PR TITLE
Make DoSetMuonJetEMScale configurable

### DIFF
--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -125,6 +125,10 @@ EL::StatusCode METConstructor :: initialize ()
   if ( m_doMuonPFlowBugfix ) {
     ANA_CHECK(m_metmaker_handle.setProperty("DoMuonPFlowBugfix", true));
   }
+  if( !m_DoSetMuonJetEMScale ){
+    ANA_CHECK(m_metmaker_handle.setProperty("DoSetMuonJetEMScale", false));
+  }
+
   ANA_CHECK(m_metmaker_handle.retrieve());
   ANA_MSG_DEBUG("Retrieved tool: " << m_metmaker_handle);
 

--- a/xAODAnaHelpers/METConstructor.h
+++ b/xAODAnaHelpers/METConstructor.h
@@ -67,6 +67,9 @@ public:
   */
   bool    m_addSoftClusterTerms = false;
 
+  //Set Muon Jet EM scale, defaults to true, should be switched off if muons are not included
+  bool m_DoSetMuonJetEMScale = true;
+
   // MET significance
   /// @brief Enable MET significance calculation
   bool m_calculateSignificance = false;


### PR DESCRIPTION
DoSetMuonJetEMScale needs to be set to false if the muon container is not included. At present this property is not exposed by the METConstructor.