### PR TITLE
Add support for plotting the xAH::MetContainer to MetHists

### DIFF
--- a/Root/MetHists.cxx
+++ b/Root/MetHists.cxx
@@ -69,3 +69,27 @@ StatusCode MetHists::execute( const xAOD::MissingETContainer* met, float eventWe
   return StatusCode::SUCCESS;
 }
 
+StatusCode MetHists::execute(const xAH::MetContainer* met, float eventWeight){
+  if(m_debug) std::cout << "MetHists: in execute " <<std::endl;
+
+  //
+  // ("FinalClus" uses the calocluster-based soft terms, "FinalTrk" uses the track-based ones)
+  //
+  m_metFinalClus      -> Fill( met->m_metFinalClus,      eventWeight);
+  m_metFinalClusPx    -> Fill( met->m_metFinalClusPx,    eventWeight);
+  m_metFinalClusPy    -> Fill( met->m_metFinalClusPy,    eventWeight);
+  m_metFinalClusSumEt -> Fill( met->m_metFinalClusSumEt, eventWeight);
+  m_metFinalClusPhi   -> Fill( met->m_metFinalClusPhi,   eventWeight);
+
+  //
+  // ("FinalClus" uses the calocluster-based soft terms, "FinalTrk" uses the track-based ones)
+  //
+  m_metFinalTrk       -> Fill( met->m_metFinalTrk,       eventWeight);
+  m_metFinalTrkPx     -> Fill( met->m_metFinalTrkPx,     eventWeight);
+  m_metFinalTrkPy     -> Fill( met->m_metFinalTrkPy,     eventWeight);
+  m_metFinalTrkSumEt  -> Fill( met->m_metFinalTrkSumEt,  eventWeight);
+  m_metFinalTrkPhi    -> Fill( met->m_metFinalTrkPhi  ,  eventWeight);
+
+  return StatusCode::SUCCESS;
+}
+

--- a/xAODAnaHelpers/MetHists.h
+++ b/xAODAnaHelpers/MetHists.h
@@ -4,6 +4,7 @@
 #include "xAODAnaHelpers/HistogramManager.h"
 #include "xAODAnaHelpers/HelperClasses.h"
 #include "xAODMissingET/MissingETContainer.h"
+#include "xAODAnaHelpers/MetContainer.h"
 
 class MetHists : public HistogramManager
 {
@@ -16,6 +17,7 @@ class MetHists : public HistogramManager
     bool m_debug;
     StatusCode initialize();
     StatusCode execute( const xAOD::MissingETContainer* met, float eventWeight );
+    StatusCode execute( const xAH::MetContainer* met, float eventWeight);
 
     using HistogramManager::book; // make other overloaded version of book() to show up in subclass
     using HistogramManager::execute; // overload


### PR DESCRIPTION
MET hists does not currently support plotting from the xAH Met Container. Other objects eg Muons support both. At later stages in an analysis the xAOD container is not available. 

Add second version of execute which solves this