### PR TITLE
Load the online beamspot info only when needed

### DIFF
--- a/Root/OnlineBeamSpotTool.cxx
+++ b/Root/OnlineBeamSpotTool.cxx
@@ -14,8 +14,20 @@ OnlineBeamSpotTool::OnlineBeamSpotTool() :
   m_cachedLB(-1),
   m_cachedRunInfo(nullptr),
   m_cachedLBData(nullptr),
-  m_mcLBData(nullptr)
+  m_mcLBData(nullptr),
+  m_files_loaded(false)
 {
+  m_mcLBData = new LBData(0,999999,0,0,0);
+}
+
+OnlineBeamSpotTool::~OnlineBeamSpotTool()
+{
+  //std::cout << "In ~OnlineBeamSpotTool" << std::endl;
+}
+
+void OnlineBeamSpotTool::readFiles(){
+  if(m_files_loaded){return;}
+
   readFile("xAODAnaHelpers/OnlineBSInfo/OnlineBSInfo.2016.A.root");
   readFile("xAODAnaHelpers/OnlineBSInfo/OnlineBSInfo.2016.B.root");
   readFile("xAODAnaHelpers/OnlineBSInfo/OnlineBSInfo.2016.C.root");
@@ -38,16 +50,17 @@ OnlineBeamSpotTool::OnlineBeamSpotTool() :
   readFile("xAODAnaHelpers/OnlineBSInfo/OnlineBSInfo.2017.I.root");
   readFile("xAODAnaHelpers/OnlineBSInfo/OnlineBSInfo.2017.K.root");
 
-  m_mcLBData = new LBData(0,999999,0,0,0);
-}
-
-OnlineBeamSpotTool::~OnlineBeamSpotTool()
-{
-  //std::cout << "In ~OnlineBeamSpotTool" << std::endl;
+  m_files_loaded = true;
 }
 
 
 void OnlineBeamSpotTool::setRunInfo(int runNumber){
+  //The Online Beamspot Info is actually being used
+  if(!m_files_loaded){
+    //Load the files at this point
+    readFiles();
+  }
+  
   RunToLBDataMapItr it = m_runList.find(runNumber);
 
   if(it != m_runList.end()){

--- a/xAODAnaHelpers/OnlineBeamSpotTool.h
+++ b/xAODAnaHelpers/OnlineBeamSpotTool.h
@@ -55,6 +55,8 @@ namespace xAH {
     const LBData*  getLBData(int lumiBlock);
 
     void setRunInfo(int runNumber);
+
+    void readFiles();
     void readFile(std::string rootFileName);
 
     RunToLBDataMap m_runList;
@@ -65,7 +67,7 @@ namespace xAH {
     LBData*  m_cachedLBData;
     LBData*  m_mcLBData;
 
-
+    bool m_files_loaded;
   };
 
 }//xAH


### PR DESCRIPTION
The online beamspot info files are loaded everytime OnlineBeamspotTool is constructed, this in turn leads to these files being read everytime JetHist is constructed as well, regardless of if beamspot is enabled. This affects performance as well as creating a burst of IO. 

Defer to read until first use when all files will be loaded, avoiding any external API changes for the tool rather than having to ensure all users update (so that a separate call to a load method could be required)